### PR TITLE
Do not process anything is debug is not activated

### DIFF
--- a/DependencyInjection/GifExceptionExtension.php
+++ b/DependencyInjection/GifExceptionExtension.php
@@ -58,6 +58,10 @@ class GifExceptionExtension extends Extension implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (!$container->getParameter('kernel.debug')) {
+            return;
+        }
+
         $definition = $container->getDefinition('gif_exception.listener.replace_image');
 
         $definition->addArgument($container->getParameter('twig.exception_listener.controller'));


### PR DESCRIPTION
The extension load is not run if the kernel debug is not activated.

We have to do the same on `GifExceptionExtension::process` method or we will get an error like below.

```
You have requested a non-existent service "gif_exception.listener.replace_image".
```

To reproduce, just try to produce an error under test env with no debug activated.
