### PR TITLE
updated PHPCSFixer organization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/framework-bundle": "~2.3|~3.0"
     },
     "require-dev": {
-        "fabpot/php-cs-fixer": "^1.11",
+        "friendsofphp/php-cs-fixer": "^1.11",
         "phpunit/phpunit": "~4.8|~5.0",
         "symfony/config": "~2.3|~3.0",
         "symfony/dependency-injection": "~2.3|~3.0"


### PR DESCRIPTION
Hi my friends !

You should saw a deprecated notice when using composer install, this should be solved using the correct organization for PHP CS Fixer :)

Mickaël
