### PR TITLE
Remove getParent call to TwigBundle

### DIFF
--- a/DependencyInjection/GifExceptionExtension.php
+++ b/DependencyInjection/GifExceptionExtension.php
@@ -11,6 +11,8 @@
 
 namespace Joli\GifExceptionBundle\DependencyInjection;
 
+use Joli\GifExceptionBundle\Command\GifOptimizerCommand;
+use Joli\GifExceptionBundle\EventListener\ReplaceImageListener;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -29,7 +31,13 @@ class GifExceptionExtension extends Extension implements CompilerPassInterface
             return;
         }
 
-        $definition = new Definition('Joli\GifExceptionBundle\EventListener\ReplaceImageListener');
+        $definition = new Definition(GifOptimizerCommand::class);
+        $definition->addTag('console.command', [
+            'command' => GifOptimizerCommand::COMMAND_NAME, // Allow lazy loading
+        ]);
+        $container->setDefinition(GifOptimizerCommand::class, $definition);
+
+        $definition = new Definition(ReplaceImageListener::class);
         $definition->addTag('kernel.event_listener', [
             'event' => KernelEvents::RESPONSE,
             'priority' => -1000,

--- a/GifExceptionBundle.php
+++ b/GifExceptionBundle.php
@@ -22,9 +22,4 @@ class GifExceptionBundle extends Bundle
 
         $container->addCompilerPass($this->getContainerExtension());
     }
-
-    public function getParent()
-    {
-        return 'TwigBundle';
-    }
 }


### PR DESCRIPTION
This Bundle throw a deprecated error on SF 3.4:

```
User Deprecated: Bundle inheritance is deprecated as of 3.4 and will be removed in 4.0.
```

This was caused by this piece of code which I believe is just old useless code form when we overrided the Twig Bundle template.