### PR TITLE
Fix fatal error compatibility

### DIFF
--- a/EventListener/ReplaceImageListener.php
+++ b/EventListener/ReplaceImageListener.php
@@ -18,8 +18,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class ReplaceImageListener implements EventSubscriberInterface
 {
-    private const IMAGES_DIR = '../../Resources/public/images';
-
     /** @var string[][] */
     private $gifs;
 
@@ -49,10 +47,16 @@ class ReplaceImageListener implements EventSubscriberInterface
             return;
         }
 
+        $exception = $event->getRequest()->attributes->get('exception');
         // Status code is not set by the exception controller but only by the
         // kernel at the very end.
         // So lets use the status code from the flatten exception instead.
-        $statusCode = $event->getRequest()->attributes->get('exception')->getStatusCode();
+        // Unless it comes from a fatal error handler
+        if ($exception instanceof \Error) {
+            $statusCode = $exception->getCode();
+        } else {
+            $statusCode = $exception->getStatusCode();
+        }
 
         $dir = $this->getGifDir($statusCode);
         $gif = $this->getRandomGif($dir);


### PR DESCRIPTION
With symfony/error-handler, all fatal error work with a "error enhancers" and based on \Error type.

Without this code, the replacement on a fatal error does not work