### PR TITLE
Fix exception status code

### DIFF
--- a/EventListener/ReplaceImageListener.php
+++ b/EventListener/ReplaceImageListener.php
@@ -59,11 +59,11 @@ class ReplaceImageListener implements EventSubscriberInterface
         // Status code is not set by the exception controller but only by the
         // kernel at the very end.
         // So lets use the status code from the flatten exception instead.
-        // Unless it comes from a fatal error handler
-        if ($exception instanceof \Error) {
-            $statusCode = $exception->getCode();
-        } else {
+        // Unless it comes from a fatal error handler or exception base class
+        if (method_exists($exception, 'getStatusCode')) {
             $statusCode = $exception->getStatusCode();
+        } else {
+            $statusCode = $exception->getCode();
         }
 
         $dir = $this->getGifDir($statusCode);


### PR DESCRIPTION
Hello,

We created a new Symfony project with @nispeon, today with this funny dependency.

The SF command "make:auth" will throw an \Exception on `src/Security/UserAuthentificatorAuthenticator.php` https://github.com/symfony/maker-bundle/blob/main/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php#L107.

![image](https://user-images.githubusercontent.com/1866496/124497052-9649b300-ddba-11eb-8f09-43fd222836ec.png)

Now, it will use the method getStatusCode if available. If not, fallback to getCode (native in PHP base exception) 