### PR TITLE
Fix Symfony deprecation about internal class usage

### DIFF
--- a/DependencyInjection/GifExceptionExtension.php
+++ b/DependencyInjection/GifExceptionExtension.php
@@ -13,8 +13,8 @@ namespace Joli\GifExceptionBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class GifExceptionExtension extends Extension
 {


### PR DESCRIPTION
> The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Joli\GifExceptionBundle\DependencyInjection\GifExceptionExtension".